### PR TITLE
Suppress CVE-2023-35116.

### DIFF
--- a/src/test/resources/owasp-dependency-check.xml
+++ b/src/test/resources/owasp-dependency-check.xml
@@ -1,3 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>
+            We are on Camel >= 4.7.0, so we are not affected.
+            The plugin thinks we are affected because we use org.apache.camel.quarkus:camel-quarkus-xpath 3.13.0.
+        </notes>
+        <cve>CVE-2023-35116</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
The CVE affects older camel versions (especially 3.13.x). We use camel 4.7.0. But we "pull-in" camel through org.apache.camel.quarkus:camel-quarkus-xpath in version 3.13.0. This is what triggers the false-positive.